### PR TITLE
Proposed fix for using the timezone setting from the watch.

### DIFF
--- a/src/DataTypes.cpp
+++ b/src/DataTypes.cpp
@@ -85,7 +85,13 @@ time_t GpsTime::mktime() {
 }
 
 std::string GpsTime::format() const {
-    return fmt() << put_time(&time, "%Y-%m-%dT%H:%M:%S");
+    std::string fmt_time = fmt() << put_time(&time, "%Y-%m-%dT%H:%M:%S%z");
+    if(fmt_time.length() >= 24){
+	    //insert missing ':' in the time zone. put_time timezone:"+0100"
+        //                                     XML      timezone:"+01:00"
+        fmt_time.insert((fmt_time.length() -2) ,":");
+    } 
+    return fmt_time;
     // does not work with windows:
     //return fmt() << put_time(&time, "%FT%TZ");
 }

--- a/src/Watch.hpp
+++ b/src/Watch.hpp
@@ -28,9 +28,9 @@ class Watch {
     void parseGpsEle(GpsEle& l, WatchMemoryBlock::mem_it_t it);
     void parseGpsLocation(GpsLocation& l, WatchMemoryBlock::mem_it_t it);
     void parseGpsTimeUpd(GpsTimeUpd& t, WatchMemoryBlock::mem_it_t it);
-    void parseGpsTime(GpsTime& t, WatchMemoryBlock::mem_it_t it);
-    void parseSample(SampleInfo& si, WatchMemoryBlock::mem_it_t& it);
-    void parseWO(WorkoutInfo& wo, int first, int count);
+    void parseGpsTime(GpsTime& t, WatchMemoryBlock::mem_it_t it, unsigned timezone);
+    void parseSample(WatchInfo& wi, SampleInfo& si, WatchMemoryBlock::mem_it_t& it);
+    void parseWO(WatchInfo& wi, int first, int count);
     void parseToc(Toc& toc, WatchMemoryBlock::mem_it_t it);
     void parseBlock0();
 


### PR DESCRIPTION
The fix adds the timezone as set in the watch to the file name and TCX data.
Resulting in a correct time in for instance Runkeeper.