### PR TITLE
GPS elevation can be negative

### DIFF
--- a/src/DataTypes.hpp
+++ b/src/DataTypes.hpp
@@ -39,7 +39,7 @@ struct GpsTimeUpd {
 };
 
 struct GpsEle {
-    unsigned short ele;
+    short ele;
     GpsEle& operator += (const GpsEle& other);
     std::string format() const;
 };


### PR DESCRIPTION
When negative elevation overflows `unsigned short GpsEle::ele` it becomes 65535 instead of -1