### PR TITLE
Make sure the time-zone setting of the watch is used in the timestamps.

### DIFF
--- a/src/DataTypes.cpp
+++ b/src/DataTypes.cpp
@@ -60,7 +60,11 @@ GpsTime::GpsTime() : time () {
                  light  saving time is in effect, zero if it is not, and nega‐$
                  tive if the information is not available.$
     */
-    time.tm_isdst = 0;
+    /* 
+     * Initialize tm_isdst to -1 glib's mktime() will set it to the systems dst.
+     * If tm_isdst is not equal to the systems dst, time will be off by +/- 1 hour .
+     */
+    time.tm_isdst = -1;
 }
 
 GpsTime& GpsTime::operator=(const GpsTimeUpd& other) {
@@ -71,7 +75,9 @@ GpsTime& GpsTime::operator=(const GpsTimeUpd& other) {
 }
 
 time_t GpsTime::mktime() {
+	tm timesave = time; //backup current time structure to preserve the watch's time-zone
     time_t t = ::mktime(&time);
+    time.tm_gmtoff = timesave.tm_gmtoff; //restore the watch's time-zone
     if (t == (time_t) -1) {
         throw std::runtime_error(fmt() << "failed to mktime: " << strerror(errno));
     }

--- a/src/DebugWriter.cpp
+++ b/src/DebugWriter.cpp
@@ -41,7 +41,7 @@ void DebugWriter::onWorkout(const WorkoutInfo &i)  {
           << std::endl
           << " workout info"
           << " p=" << i.profile
-          << " t=" << i.start_time.format()
+          << " t=" << i.start_time.format() << " dst=" << i.start_time.time.tm_isdst
           << " d=" << put_time(&i.workout_time.time, "%H:%M:%S") << "=" << i.workout_time.time.tm_hour*60*60 + i.workout_time.time.tm_min*60 +i.workout_time.time.tm_sec
           << " nsamples=" << i.nsamples << "=0x" << std::hex << i.nsamples << std::dec
           //<< " toc=" << i.toc

--- a/src/Watch.cpp
+++ b/src/Watch.cpp
@@ -457,7 +457,7 @@ void Watch::parseWO(WatchInfo& wi, int first, int count) {
                 t.time.tm_hour ++;
                 // mktime fixes clock info, 
                 // 23:50 + 1h = 24:50; mktime increments day automatically.
-                mktime(&t.time);
+                t.mktime();
             }
             si.time = (t = si.time_upd);
         }


### PR DESCRIPTION
The glib mktime() function ignores tm_gmtoff value. It takes the systems time-zone and overwrites the value set by the user of tm_gmtoff.
In the solution tm_gmtoff is saved before calling mktime() and then restored.
Also tm_isdst is initialized to -1 so mktime() can set the actual dst value. This is needed for puttime() so it does not change the hour value.
With these fixes the time-zone and time values should match the values on the watch.